### PR TITLE
Avoid basic adapter deletion

### DIFF
--- a/.linter.conf
+++ b/.linter.conf
@@ -1,0 +1,4 @@
+{
+  "DisableAll": true,
+  "Enable": ["golint", "vet", "errcheck"]
+}

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ deps:
 	go get github.com/ernestio/ernest-config-client
 	go get github.com/stvp/rollbar
 
-dev-deps:
+dev-deps: deps
 	go get github.com/smartystreets/goconvey/convey
 	go get github.com/alecthomas/gometalinter
 	gometalinter --install

--- a/Makefile
+++ b/Makefile
@@ -5,21 +5,21 @@ build:
 	go build -v ./...
 
 lint:
-	golint ./...
-	go vet ./...
+	gometalinter --config .linter.conf
 
 test:
 	go test -v ./... --cover
 
-deps: dev-deps
+deps:
 	go get github.com/r3labs/nats_to_logstash
 	go get github.com/nats-io/nats
 	go get github.com/ernestio/ernest-config-client
 	go get github.com/stvp/rollbar
 
 dev-deps:
-	go get github.com/golang/lint/golint
 	go get github.com/smartystreets/goconvey/convey
+	go get github.com/alecthomas/gometalinter
+	gometalinter --install
 
 clean:
 	go clean

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ $ make install
 
 Running the tests:
 ```
-make test
+$ make dev-deps
+$ make test
 ```
 
 ## Contributing

--- a/adapters/adapter.go
+++ b/adapters/adapter.go
@@ -1,0 +1,8 @@
+package adapters
+
+// Adapter : interface for Logger adapters
+type Adapter interface {
+	Manage([]string, MessageProcessor) error
+	Stop()
+	Name() string
+}

--- a/adapters/basic.go
+++ b/adapters/basic.go
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package main
+package adapters
 
 import (
 	"encoding/json"

--- a/adapters/logstash.go
+++ b/adapters/logstash.go
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package main
+package adapters
 
 import (
 	"bytes"
@@ -51,7 +51,7 @@ func NewLogstashAdapter(nc *nats.Conn, config []byte) (Adapter, error) {
 }
 
 // Manage : Manages the subscriptions
-func (l *LogstashAdapter) Manage(subjects []string, fn MessageProcessor) error {
+func (l *LogstashAdapter) Manage(subjects []string, fn MessageProcessor) (err error) {
 	for _, subject := range subjects {
 		s, _ := l.Client.Subscribe(subject, func(m *nats.Msg) {
 
@@ -62,7 +62,7 @@ func (l *LogstashAdapter) Manage(subjects []string, fn MessageProcessor) error {
 			if body, err := json.Marshal(lg); err != nil {
 				log.Println(err.Error())
 			} else {
-				if err := l.writeln(body); err != nil {
+				if err = l.writeln(body); err != nil {
 					log.Println(err.Error())
 				}
 			}

--- a/adapters/rollbar.go
+++ b/adapters/rollbar.go
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package main
+package adapters
 
 import (
 	"encoding/json"

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 dependencies:
   pre:
-    - make deps
+    - make dev-deps
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,15 @@
+machine:
+  environment:
+    ROOTPATH: /home/ubuntu/.go_workspace/src/github.com/ernestio
+
 dependencies:
   pre:
-    - make dev-deps
+    - mkdir -p $ROOTPATH/
+    - rm -rf $ROOTPATH/logger
+    - cp -R /home/ubuntu/logger $ROOTPATH/logger
+    - cd $ROOTPATH/logger/ && make dev-deps
 
 test:
   override:
-    - make lint
-    - make test
+    - cd $ROOTPATH/logger/ && make test
+    - cd $ROOTPATH/logger/ && make lint

--- a/main.go
+++ b/main.go
@@ -64,8 +64,9 @@ type GenericAdapter struct {
 var newAdapterListener = func(m *nats.Msg) {
 	var adapter GenericAdapter
 	if err := json.Unmarshal(m.Data, &adapter); err != nil {
-		log.Println("Error processing logger.set message")
+		log.Println("Error processing logger creation")
 		log.Println(err.Error())
+		return
 	}
 
 	switch adapter.Type {
@@ -90,14 +91,28 @@ var newAdapterListener = func(m *nats.Msg) {
 var deleteAdapterListener = func(m *nats.Msg) {
 	var adapter GenericAdapter
 	if err := json.Unmarshal(m.Data, &adapter); err != nil {
-		log.Println("Error processing logger.set message")
+		log.Println("Error processing logger deletion")
 		log.Println(err.Error())
 		if err := nc.Publish(m.Reply, []byte(`{"error":"`+err.Error()+`"}`)); err != nil {
 			log.Println(err.Error())
+			return
 		}
 	}
 
-	if adapter.Type == "basic" || adapter.Type == "logstash" || adapter.Type == "rollbar" {
+	if adapter.Type == "basic" {
+		if silent == true {
+			adapters[adapter.Type].Stop()
+			adapters[adapter.Type] = nil
+		} else {
+			log.Println("Basic adapter is not optional")
+			if err := nc.Publish(m.Reply, []byte(`{"error":"Basic logger is not optional"}`)); err != nil {
+				log.Println(err.Error())
+			}
+		}
+		return
+	}
+
+	if adapter.Type == "logstash" || adapter.Type == "rollbar" {
 		if _, ok := adapters[adapter.Type]; ok && adapters[adapter.Type] != nil {
 			adapters[adapter.Type].Stop()
 			adapters[adapter.Type] = nil
@@ -114,7 +129,6 @@ var deleteAdapterListener = func(m *nats.Msg) {
 		if err := nc.Publish(m.Reply, []byte(`{"error":"Invalid logger type"}`)); err != nil {
 			log.Println(err.Error())
 		}
-
 	}
 }
 

--- a/persister.go
+++ b/persister.go
@@ -36,7 +36,9 @@ func persist(m *nats.Msg) {
 			return
 		}
 		err = ioutil.WriteFile(file, []byte("{}"), 0644)
-		defer f.Close()
+		defer func() {
+			_ = f.Close()
+		}()
 	}
 
 	dat, err := ioutil.ReadFile(file)


### PR DESCRIPTION
Basic logger should be always up, so basically this pull request disables the public interface to disable it.

Additionally a small cleanup has been done, basically by moving all adapters to its own package.